### PR TITLE
CRS typos

### DIFF
--- a/openapi/swaggerhub/maps.yaml
+++ b/openapi/swaggerhub/maps.yaml
@@ -165,12 +165,12 @@ paths:
 
             The response contains the list of collections. For each collection, a link
             to other resources present (e.g. the items in the collection, path `/collections/{collectionId}/items`,
-            link relation `items`, a map created with data from  collection, path `/collections/{collectionId}/map`,
+            link relation `items`, a map created with data from the collection, path `/collections/{collectionId}/map`,
             link relation `map`) as well as key information about the collection.
             This information includes, but is not limited to:
 
             * A local identifier for the collection that is unique for the dataset;
-            * A list of coordinate reference systems (CRS) in which geometries may be returned by the server. The first CRS is the default coordinate reference system (the default is always WGS84 with axis order longitude/latitude);
+            * A list of coordinate reference systems (CRS) in which maps may be returned by the server. The first CRS is the default coordinate reference system (the default is always WGS84 with axis order longitude/latitude);
             * An optional title and description for the collection;
             * An optional extent that can be used to provide an indication of the spatial and temporal extent of the collection - typically derived from the data;
           content:
@@ -342,7 +342,7 @@ paths:
           * Upper right corner, coordinate axis 1
           * Upper right corner, coordinate axis 2
 
-          coordinate reference system (and axis order) of the four values is specified in the 'crs' parametre. It the 'crs' parametres is CRS84, the sequence is minimum longitude, minimum latitude, maximum longitude and maximum latitude.
+          coordinate reference system (and axis order) of the four values is specified in the 'crs' parameter. It the 'crs' parameter is CRS84, the sequence is minimum longitude, minimum latitude, maximum longitude and maximum latitude.
           However, in cases where the box spans the antimeridian the first value (west-most box edge) is larger than the third value (east-most box edge).
         required: false
         style: form


### PR DESCRIPTION
In some mentions of the CRS parameter, replaced "geometries" with "maps" since this API deals with raster, not vector, data. Minor typo fixes as well.