### PR TITLE
add pygeoapi and OWSLib to implementations

### DIFF
--- a/implementations.adoc
+++ b/implementations.adoc
@@ -20,6 +20,10 @@
 | OGC API - Maps
 | https://github.com/aaime[Andrea Aime]
 
+| https://pygeoapi.io[pygeoapi]
+| OGC API - Maps
+| https://github.com/tomkralidis[Tom Kralidis]
+
 | TBA
 | TBA
 | TBA

--- a/implementations.adoc
+++ b/implementations.adoc
@@ -54,6 +54,10 @@
 | OGC API - Maps
 | https://github.com/joanma747[Joan Masó]
 
+| https://geopython.github.io/OWSLib[OWSLib]
+| OGC API - Maps
+| https://github.com/tomkralidis[Tom Kralidis]
+
 | TBA
 | TBA
 | TBA


### PR DESCRIPTION
OAMaps is now supported in pygeoapi: https://github.com/geopython/pygeoapi/pull/1048 and OWSLib: https://github.com/geopython/OWSLib/pull/847