### PR TITLE
change version number from 1.0 to 1.0.0-draft

### DIFF
--- a/openapi/ogcapi-maps-1.bundled.json
+++ b/openapi/ogcapi-maps-1.bundled.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.0",
   "info": {
-    "version": "1.0",
+    "version": "1.0.0-draft",
     "title": "OGC API - Maps",
     "description": "Example API Definition for OGC API - Maps - Part 1: Core",
     "contact": {

--- a/openapi/ogcapi-maps-1.yaml
+++ b/openapi/ogcapi-maps-1.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-   version: '1.0'
+   version: '1.0.0-draft'
    title: OGC API - Maps
    description: |-
       Example API Definition for OGC API - Maps - Part 1: Core


### PR DESCRIPTION
This makes it clearer that the draft standard is not yet approved. It will minimise the risk of confusing future implementers.